### PR TITLE
dapp-runner integrated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ python = "^3.8"
 psutil = "^5.9"
 appdirs = "^1.4"
 click = "^8.1"
-dapp-runner = { git = "ssh://git@github.com/golemfactory/dapp-runner.git", branch="blue/streams" }
+dapp-runner = { git = "https://github.com/golemfactory/dapp-runner.git", branch = "main" }
 
 [tool.poetry.dev-dependencies]
 black = "^22.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ python = "^3.8"
 psutil = "^5.9"
 appdirs = "^1.4"
 click = "^8.1"
+dapp-runner = { git = "ssh://git@github.com/golemfactory/dapp-runner.git", branch="blue/streams" }
 
 [tool.poetry.dev-dependencies]
 black = "^22.1"

--- a/sample_config.yml
+++ b/sample_config.yml
@@ -1,0 +1,11 @@
+yagna:
+  api_url: "http://localhost:6765"
+  gsb_url: "tcp://127.0.0.1:6766"
+  app_key: "$YAGNA_APPKEY"
+  subnet_tag: "devnet-beta"
+
+
+payment:
+  budget: 1.0
+  driver: "zksync"
+  network: "rinkeby"

--- a/sample_descriptor.yml
+++ b/sample_descriptor.yml
@@ -1,0 +1,12 @@
+payloads:
+  simple-service:
+    runtime: "vm"
+    params:
+      image_hash: "8b11df59f84358d47fc6776d0bb7290b0054c15ded2d6f54cf634488"
+nodes:
+  simple-service:
+    payload: "simple-service"
+    entrypoint:
+        - ["/golem/run/simulate_observations_ctl.py", "--start"]
+        - ["/bin/sh", "-c", "sleep 15" ]
+        - [ "/golem/run/simple_service.py", "--stats"]

--- a/yagna_dapp_manager/dapp_starter.py
+++ b/yagna_dapp_manager/dapp_starter.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from .storage import SimpleStorage
 
+DEFAULT_EXEC_STR = "python3 -m dapp_runner"
+
 
 class DappStarter:
     def __init__(self, descriptors: List[Path], config: Path, storage: SimpleStorage):
@@ -23,7 +25,7 @@ class DappStarter:
         self.storage.save_pid(proc.pid)
 
     def _get_command(self):
-        return [self._executable()] + self._cli_args()
+        return self._executable() + self._cli_args()
 
     def _cli_args(self) -> List[str]:
         """Return the dapp-runner CLI command and args."""
@@ -35,12 +37,9 @@ class DappStarter:
         args += [str(d.resolve()) for d in self.descriptors]
         return args
 
-    def _executable(self) -> str:
+    def _executable(self) -> List[str]:
         """Return the "dapp-runner" executable - either set by the env variable or the default.
 
         Env variable is intended mostly for the testing/debugging purposes."""
-        executable = os.environ["DAPP_RUNNER_EXEC"]
-        if not executable:
-            # TODO: https://github.com/golemfactory/dapp-manager/issues/5
-            raise NotImplementedError
-        return executable
+        executable_str = os.environ.get("DAPP_RUNNER_EXEC", DEFAULT_EXEC_STR)
+        return list(executable_str.split())


### PR DESCRIPTION
Resolves #5 

`dapp-runner` repo url should be updated when:
* `dapp-runner` repo goes public. NOTE: CI tests will **not** work until then, as it will not install from a private repo - and we shouldn't merge this branch until then
* `blue/streams` branch is merged

ALSO: please accept `sample_config` and `sample_descriptor` the way they are now - this will all disappear in the future, but for now it's just useful for the development.

TEST:

```
$ pip3 install git+https://github.com/golemfactory/dapp-manager@jb/integrate-dapp-runner
(...)
$ python3 -m yagna_dapp_manager start --config sample_config.yml sample_descriptor.yml
8cfe37c616524d23920bd9412c1ae3b9
$ python3 -m yagna_dapp_manager raw-state --app-id 8cfe37c616524d23920bd9412c1ae3b9 
{"simple-service": {"0": "pending"}}
{"simple-service": {"0": "starting"}
$ python3 -m yagna_dapp_manager raw-state --app-id 8cfe37c616524d23920bd9412c1ae3b9
{"simple-service": {"0": "pending"}}
{"simple-service": {"0": "starting"}}
{"simple-service": {"0": "running"}}
$ python3 -m yagna_dapp_manager stop --app-id 8cfe37c616524d23920bd9412c1ae3b9
8cfe37c616524d23920bd9412c1ae3b9
$ python3 -m yagna_dapp_manager raw-state --app-id 8cfe37c616524d23920bd9412c1ae3b9
App 8cfe37c616524d23920bd9412c1ae3b9 is not running.
# issue #26 
$ cat ~/.local/share/dapp_manager/8cfe37c616524d23920bd9412c1ae3b9/state 
{"simple-service": {"0": "pending"}}
{"simple-service": {"0": "starting"}}
{"simple-service": {"0": "running"}}
{"simple-service": {"0": "stopping"}}
{"simple-service": {"0": "terminated"}}
```
