### PR TITLE
Read `yapapi` log file

### DIFF
--- a/sample_usage.py
+++ b/sample_usage.py
@@ -2,14 +2,14 @@ from yagna_dapp_manager import DappManager
 
 #   New app
 dapp = DappManager.start("golem_compose.yml", config="config_file.yml")
-print(dapp.raw_data())
-print(dapp.raw_state())
+print(dapp.read_file("data"))
+print(dapp.read_file("state"))
 
 #   Old app
 app_id = DappManager.list()[0]
 dapp = DappManager(app_id)
-print(dapp.raw_data())
-print(dapp.raw_state())
+print(dapp.read_file("data"))
+print(dapp.read_file("state"))
 
 #   Stop the app
 app_id = DappManager.list()[0]

--- a/tests/assets/mock_dapp_runner.py
+++ b/tests/assets/mock_dapp_runner.py
@@ -6,9 +6,10 @@
 
 from pathlib import Path
 from time import sleep
-from typing import Tuple
+from typing import Tuple, TextIO
 from itertools import count
 from random import random
+import sys
 
 import click
 
@@ -34,6 +35,13 @@ def _cli():
     help="Path to the state file.",
 )
 @click.option(
+    "--log",
+    "-l",
+    required=False,
+    type=Path,
+    help="Path to the log file.",
+)
+@click.option(
     "--config",
     "-c",
     required=True,
@@ -55,18 +63,28 @@ def start(
     data_file = open(kwargs["data"], "w", buffering=1)
     state_file = open(kwargs["state"], "w", buffering=1)
 
+    log_file: TextIO
+    if kwargs.get("log"):
+        log_file = open(kwargs["log"], "w", buffering=1)
+    else:
+        log_file = sys.stdout
+
     try:
+        log_file.write("engine started...")
         for i in count(1):
             state_file.write(f"Running for {i} seconds\n")
+
             if i == 3:
                 data_file.write(f"Important data received: {random()}\n")
             sleep(1)
     except KeyboardInterrupt:
         state_file.write("Shutting down\n")
         sleep(3)
+        log_file.write("engine stopped.")
         state_file.write("Graceful shutdown finished\n")
         data_file.close()
         state_file.close()
+        log_file.close()
 
 
 if __name__ == "__main__":

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,9 +29,9 @@ def start_dapp(
     def _get_command(self):
         command = base_command.copy()
         if state_file:
-            command = command + [str(self.storage.state_file.resolve())]
+            command = command + [str(self.storage.file_name("state").resolve())]
         if data_file:
-            command = command + [str(self.storage.data_file.resolve())]
+            command = command + [str(self.storage.file_name("data").resolve())]
         return command
 
     with mock.patch(
@@ -75,9 +75,10 @@ def asset_path(name):
 #   All instance methods/propeties, with sample args
 #   (Possible TODO: it would be probably better to create this in a dynamic way,
 #   using inspect - now we risk that some new method will not be tested).
-all_dm_methods_args: Tuple[Union[Tuple[str], Tuple[str, int]], ...] = (
-    ("raw_data",),
-    ("raw_state",),
+#   ALSO: probably the best solution is to just remove this and have explicit listings
+all_dm_methods_args: Tuple[Union[Tuple[str], Tuple[str, int], Tuple[str, str]], ...] = (
+    ("read_file", "state"),
+    ("read_file", "data"),
     ("stop", 1),
     ("kill",),
 )

--- a/yagna_dapp_manager/__main__.py
+++ b/yagna_dapp_manager/__main__.py
@@ -123,5 +123,14 @@ def raw_data(*, app_id, ensure_alive):
     print(dapp.read_file("data", ensure_alive))
 
 
+@_cli.command()
+@_with_app_id
+@_capture_api_exceptions
+@_with_ensure_alive
+def log(*, app_id, ensure_alive):
+    dapp = DappManager(app_id)
+    print(dapp.read_file("log", ensure_alive))
+
+
 if __name__ == "__main__":
     _cli()

--- a/yagna_dapp_manager/__main__.py
+++ b/yagna_dapp_manager/__main__.py
@@ -111,7 +111,7 @@ def kill(*, app_id):
 @_with_ensure_alive
 def raw_state(*, app_id, ensure_alive):
     dapp = DappManager(app_id)
-    print(dapp.raw_state(ensure_alive))
+    print(dapp.read_file("state", ensure_alive))
 
 
 @_cli.command()
@@ -120,7 +120,7 @@ def raw_state(*, app_id, ensure_alive):
 @_with_ensure_alive
 def raw_data(*, app_id, ensure_alive):
     dapp = DappManager(app_id)
-    print(dapp.raw_data(ensure_alive))
+    print(dapp.read_file("data", ensure_alive))
 
 
 if __name__ == "__main__":

--- a/yagna_dapp_manager/dapp_manager.py
+++ b/yagna_dapp_manager/dapp_manager.py
@@ -10,7 +10,7 @@ import appdirs
 import psutil
 
 from .exceptions import AppNotRunning
-from .storage import SimpleStorage
+from .storage import SimpleStorage, RunnerFileType
 from .dapp_starter import DappStarter
 
 PathType = Union[str, os.PathLike]
@@ -75,23 +75,14 @@ class DappManager:
 
     ###########################
     #   PUBLIC INSTANCE METHODS
-    def raw_state(self, ensure_alive: bool = True) -> str:
-        """Return raw, unparsed contents of the 'state' stream.
+    def read_file(self, file_type: RunnerFileType, ensure_alive: bool = True) -> str:
+        """Return raw, unparsed contents of the `file_type` stream.
 
         If ensure_alive is True, AppNotRunning exception will be raised if the app is not running."""
 
         if ensure_alive:
             self._ensure_alive()
-        return self.storage.state
-
-    def raw_data(self, ensure_alive: bool = True) -> str:
-        """Return raw, unparsed contents of the 'data' stream
-
-        If ensure_alive is True, AppNotRunning exception will be raised if the app is not running."""
-
-        if ensure_alive:
-            self._ensure_alive()
-        return self.storage.data
+        return self.storage.read_file(file_type)
 
     def stop(self, timeout: int) -> bool:
         """Stop the dapp gracefully (SIGINT), waiting at most `timeout` seconds.

--- a/yagna_dapp_manager/dapp_starter.py
+++ b/yagna_dapp_manager/dapp_starter.py
@@ -3,7 +3,7 @@ from subprocess import Popen, DEVNULL
 from typing import List
 from pathlib import Path
 
-from .storage import SimpleStorage
+from .storage import SimpleStorage, RunnerFileType
 
 DEFAULT_EXEC_STR = "python3 -m dapp_runner"
 
@@ -19,7 +19,7 @@ class DappStarter:
 
         #   NOTE: Stdout and stderr are redirected to /dev/null.
         #         This will probably never change - we assume the dapp runner either has
-        #         no meaningfull stdout/stderr, or has an additional interface that allows
+        #         no meaningful stdout/stderr, or has an additional interface that allows
         #         redirecting it to a file (just like e.g. --data-file).
         proc = Popen(command, stdout=DEVNULL, stderr=DEVNULL)
         self.storage.save_pid(proc.pid)
@@ -33,8 +33,9 @@ class DappStarter:
         args = ["start"]
         args += ["--config", str(self.config.resolve())]
 
-        for file_type in ("data", "state"):
-            file_name = str(self.storage.file_name(file_type).resolve())  # type: ignore  # TODO - mypy, why?
+        # TODO: is there's a better way to iterate over elements of a Literal type?
+        for file_type in RunnerFileType.__args__:  # type: ignore [attr-defined]
+            file_name = str(self.storage.file_name(file_type).resolve())
             args += [f"--{file_type}", file_name]
 
         args += [str(d.resolve()) for d in self.descriptors]

--- a/yagna_dapp_manager/dapp_starter.py
+++ b/yagna_dapp_manager/dapp_starter.py
@@ -32,8 +32,11 @@ class DappStarter:
         # TODO: https://github.com/golemfactory/dapp-manager/issues/5
         args = ["start"]
         args += ["--config", str(self.config.resolve())]
-        args += ["--data", str(self.storage.data_file.resolve())]
-        args += ["--state", str(self.storage.state_file.resolve())]
+
+        for file_type in ("data", "state"):
+            file_name = str(self.storage.file_name(file_type).resolve())  # type: ignore  # TODO - mypy, why?
+            args += [f"--{file_type}", file_name]
+
         args += [str(d.resolve()) for d in self.descriptors]
         return args
 

--- a/yagna_dapp_manager/storage.py
+++ b/yagna_dapp_manager/storage.py
@@ -2,9 +2,11 @@ from pathlib import Path
 import os
 import shutil
 
-from typing import List
+from typing import List, Literal, Union
 
 from .exceptions import UnknownApp
+
+RunnerFileType = Literal["data", "state"]
 
 
 class SimpleStorage:
@@ -40,18 +42,9 @@ class SimpleStorage:
     def alive(self) -> bool:
         return os.path.isfile(self.pid_file)
 
-    @property
-    def state(self) -> str:
+    def read_file(self, file_type: RunnerFileType) -> str:
         try:
-            with open(self.state_file, "r") as f:
-                return f.read()
-        except FileNotFoundError:
-            return ""
-
-    @property
-    def data(self) -> str:
-        try:
-            with open(self.data_file, "r") as f:
+            with open(self.file_name(file_type), "r") as f:
                 return f.read()
         except FileNotFoundError:
             return ""
@@ -75,21 +68,15 @@ class SimpleStorage:
 
     @property
     def pid_file(self) -> Path:
-        return self._fname("pid")
+        return self.file_name("pid")
 
     @property
     def archived_pid_file(self) -> Path:
-        return self._fname("_old_pid")
+        return self.file_name("_old_pid")
 
-    @property
-    def data_file(self) -> Path:
-        return self._fname("data")
-
-    @property
-    def state_file(self) -> Path:
-        return self._fname("state")
-
-    def _fname(self, name) -> Path:
+    def file_name(
+        self, name: Union[RunnerFileType, Literal["pid", "_old_pid"]]
+    ) -> Path:
         #   NOTE: "Known app" test here is sufficient - this method will be called whenever
         #         any piece of information related to self.app_id is retrieved or changed
         self._ensure_known_app()

--- a/yagna_dapp_manager/storage.py
+++ b/yagna_dapp_manager/storage.py
@@ -6,7 +6,7 @@ from typing import List, Literal, Union
 
 from .exceptions import UnknownApp
 
-RunnerFileType = Literal["data", "state"]
+RunnerFileType = Literal["data", "state", "log"]
 
 
 class SimpleStorage:


### PR DESCRIPTION
1. Now we have "data" and "state" files, they are treated exactly the same way
2. `yapapi` (or, more generally: engine) log file should be a third file also with similar logic
3. In the future (when https://github.com/golemfactory/dapp-runner/issues/19 is done) we'll also have `runner stdout` and `runner stderr`, also similar

--> This PR:
* generalizes this sort of a file processing
* adds support for the `log` file