### PR TITLE
protect against pid recycling

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
         os:
           - ubuntu-latest
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
         os:
           - ubuntu-latest
       fail-fast: false


### PR DESCRIPTION
while checking if the app is running, ensure that the process:
* belongs to the same user
* was started before the pidfile was created

closes #12 
closes #27 
