### PR TITLE
Aggregating payload sizes

### DIFF
--- a/dapp_manager/__main__.py
+++ b/dapp_manager/__main__.py
@@ -149,7 +149,6 @@ def read():
     """Read output from the given app."""
     # this function serves only to add a CLI command group
     # and so it doesn't need any body code
-    pass
 
 
 @read.command()

--- a/dapp_manager/dapp_manager.py
+++ b/dapp_manager/dapp_manager.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 import psutil
 import re
-import signal
+import signal  # TODO: Add support for windows machines https://github.com/golemfactory/dapp-manager/issues/72
 from time import sleep
 from typing import List, Union
 import uuid
@@ -161,7 +161,7 @@ class DappManager:
         """Stop the app in a non-gracfeul way"""
         self._ensure_alive()
 
-        os.kill(self.pid, signal.SIGKILL)  # type: ignore[attr-defined]
+        os.kill(self.pid, signal.SIGKILL)
         self.storage.set_not_running()
 
     #######################
@@ -239,12 +239,12 @@ def enforce_timeout(seconds: int):
     def raise_timeout_error(signum, frame):
         raise TimeoutError
 
-    signal.signal(signal.SIGALRM, raise_timeout_error)  # type: ignore[attr-defined]
-    signal.alarm(seconds)  # type: ignore[attr-defined]
+    signal.signal(signal.SIGALRM, raise_timeout_error)
+    signal.alarm(seconds)
 
     try:
         yield
     except TimeoutError:
         pass
     finally:
-        signal.signal(signal.SIGALRM, signal.SIG_IGN)  # type: ignore[attr-defined]
+        signal.signal(signal.SIGALRM, signal.SIG_IGN)

--- a/dapp_manager/dapp_manager.py
+++ b/dapp_manager/dapp_manager.py
@@ -161,7 +161,7 @@ class DappManager:
         """Stop the app in a non-gracfeul way"""
         self._ensure_alive()
 
-        os.kill(self.pid, signal.SIGKILL)
+        os.kill(self.pid, signal.SIGKILL)  # type: ignore[attr-defined]
         self.storage.set_not_running()
 
     #######################
@@ -239,12 +239,12 @@ def enforce_timeout(seconds: int):
     def raise_timeout_error(signum, frame):
         raise TimeoutError
 
-    signal.signal(signal.SIGALRM, raise_timeout_error)
-    signal.alarm(seconds)
+    signal.signal(signal.SIGALRM, raise_timeout_error)  # type: ignore[attr-defined]
+    signal.alarm(seconds)  # type: ignore[attr-defined]
 
     try:
         yield
     except TimeoutError:
         pass
     finally:
-        signal.signal(signal.SIGALRM, signal.SIG_IGN)
+        signal.signal(signal.SIGALRM, signal.SIG_IGN)  # type: ignore[attr-defined]

--- a/dapp_stats/__main__.py
+++ b/dapp_stats/__main__.py
@@ -6,8 +6,10 @@ from pathlib import Path
 import sys
 from typing import Sequence
 
+from click import Abort, ClickException
+
 from dapp_stats import DappStats
-from dapp_stats.dapp_size_resolver import DappSizeResolver
+from dapp_stats.dapp_size_resolver import DappSizeResolver, DappSizeResolverError
 
 from .exceptions import DappStatsException
 
@@ -55,7 +57,10 @@ def stats(*, app_id):
 def size(descriptors: Sequence[Path]):
     """Calculates dApp defined payloads sizes (in bytes) on the provided set of descriptor files."""
 
-    measured_sizes, errors = DappSizeResolver.resolve_defined_payload_sizes(descriptors)
+    try:
+        measured_sizes, errors = DappSizeResolver.resolve_defined_payload_sizes(descriptors)
+    except DappSizeResolverError as e:
+        raise ClickException(str(e))
 
     for error in errors:
         click.echo(error, err=True)

--- a/dapp_stats/__main__.py
+++ b/dapp_stats/__main__.py
@@ -1,26 +1,25 @@
-import base64
-import logging
-from functools import wraps
-import sys
-import asyncio
-import json
-from pathlib import Path
-from typing import Tuple, Dict, Sequence
-
 import aiohttp
-import click
 from aiohttp.hdrs import CONTENT_LENGTH
-from dapp_runner.descriptor.parser import load_yamls
-from yapapi.payload.vm import resolve_repo_srv, _DEFAULT_REPO_SRV
-
+import asyncio
+import base64
+import click
 from dapp_runner.descriptor import DappDescriptor
+from dapp_runner.descriptor.parser import load_yamls
+from functools import wraps
+import json
+import logging
+from pathlib import Path
+import sys
+from typing import Dict, Sequence, Tuple
+from yapapi.payload.vm import _DEFAULT_REPO_SRV, resolve_repo_srv
+
 from dapp_stats import DappStats
 from dapp_stats.dapp_size_resolver import DappSizeResolver
 
 from .exceptions import DappStatsException
 
-
 logger = logging.getLogger(__name__)
+
 
 def _with_app_id(wrapped_func):
     wrapped_func = click.argument("app-id", type=str)(wrapped_func)
@@ -63,12 +62,12 @@ def stats(*, app_id):
 def size(descriptors: Sequence[Path]):
     """Calculates dApp defined payloads sizes (in bytes) on the provided set of descriptor files."""
 
-    measured_sizes, errors = DappSizeResolver.resolve_payload_size(descriptors)
+    measured_sizes, errors = DappSizeResolver.resolve_defined_payload_sizes(descriptors)
 
     for error in errors:
         click.echo(error, err=True)
 
-    click.echo(json.dumps(measured_sizes))
+    click.echo(json.dumps(measured_sizes, indent=2, default=str))
 
 
 def main():

--- a/dapp_stats/__main__.py
+++ b/dapp_stats/__main__.py
@@ -1,12 +1,25 @@
-import click
+import base64
+import logging
 from functools import wraps
-import json
 import sys
+import asyncio
+import json
+from pathlib import Path
+from typing import Tuple, Dict
 
+import aiohttp
+import click
+from aiohttp.hdrs import CONTENT_LENGTH
+from dapp_runner.descriptor.parser import load_yamls
+from yapapi.payload.vm import resolve_repo_srv, _DEFAULT_REPO_SRV
+
+from dapp_runner.descriptor import DappDescriptor
 from dapp_stats import DappStats
 
 from .exceptions import DappStatsException
 
+
+logger = logging.getLogger(__name__)
 
 def _with_app_id(wrapped_func):
     wrapped_func = click.argument("app-id", type=str)(wrapped_func)
@@ -37,6 +50,82 @@ def stats(*, app_id):
     """Returns the stats of a given app."""
     dapp = DappStats(app_id)
     print(json.dumps(dapp.get_stats(), indent=2, default=str))
+
+
+@_cli.command()
+@click.argument(
+    "descriptors",
+    nargs=-1,
+    required=True,
+    type=Path,
+)
+def size(descriptors: Tuple[Path]):
+    """Calculates dApp defined payloads sizes (in bytes) on the provided set of descriptor files."""
+
+    logger.debug('Loading dApp descriptors...')
+    dapp_dict = load_yamls(*descriptors)
+    dapp = DappDescriptor.load(dapp_dict)
+
+    logger.debug('Loading dApp descriptors done')
+
+    logger.debug(f'Measuring sizes of "{len(dapp.payloads)}" defined payloads...')
+    payloads_sizes: Dict[str, int] = {}
+    for payload_name, payload in dapp.payloads.items():
+
+        async def get_image_size(image_url):
+            async with aiohttp.ClientSession() as client:
+                resp = await client.head(image_url)
+                if resp.status != 200:
+                    resp.raise_for_status()
+
+                return int(resp.headers[CONTENT_LENGTH])
+
+        if payload.runtime == 'vm':
+            image_hash = payload.params.get('image_hash')
+            if image_hash is None:
+                message = f'Ignoring payload "{payload_name}" as "image_hash" is not present in params'
+                logger.debug(message)
+                click.echo(message, err=True)
+                continue
+
+            async def resolve_package_repo_url(repo_url, image_hash):
+                async with aiohttp.ClientSession() as client:
+                    resp = await client.get(f"{repo_url}/image.{image_hash}.link")
+                    if resp.status != 200:
+                        resp.raise_for_status()
+
+                    return await resp.text()
+
+            repo_url = resolve_repo_srv(_DEFAULT_REPO_SRV)
+            loop = asyncio.get_event_loop()
+            image_url = loop.run_until_complete(resolve_package_repo_url(repo_url, image_hash))
+
+            payload_size = loop.run_until_complete(get_image_size(image_url))
+            payloads_sizes[payload_name] = payload_size
+        elif payload.runtime == 'vm/manifest':
+            manifest_hash = payload.params.get('manifest')
+            if manifest_hash is None:
+                message = f'Ignoring payload "{payload_name}" as "manifest" is not present in params'
+                logger.debug(message)
+                click.echo(message, err=True)
+                continue
+
+            manifest = json.loads(base64.b64decode(manifest_hash.encode('utf-8')))
+
+            image_url = manifest['payload'][0]['urls'][0]
+
+            loop = asyncio.get_event_loop()
+            payload_size = loop.run_until_complete(get_image_size(image_url))
+            payloads_sizes[payload_name] = payload_size
+        else:
+            message = f'Ignoring payload "{payload_name}" as size measurement for runtime "{payload.runtime}" is not ' \
+                      f'supported'
+            logger.debug(message)
+            click.echo(message, err=True)
+
+    logger.debug('Measuring sizes of defined payloads done')
+
+    click.echo(json.dumps({'total_size': sum(payloads_sizes.values()), 'payloads': payloads_sizes}))
 
 
 def main():

--- a/dapp_stats/__main__.py
+++ b/dapp_stats/__main__.py
@@ -1,17 +1,10 @@
-import aiohttp
-from aiohttp.hdrs import CONTENT_LENGTH
-import asyncio
-import base64
 import click
-from dapp_runner.descriptor import DappDescriptor
-from dapp_runner.descriptor.parser import load_yamls
 from functools import wraps
 import json
 import logging
 from pathlib import Path
 import sys
-from typing import Dict, Sequence, Tuple
-from yapapi.payload.vm import _DEFAULT_REPO_SRV, resolve_repo_srv
+from typing import Sequence
 
 from dapp_stats import DappStats
 from dapp_stats.dapp_size_resolver import DappSizeResolver

--- a/dapp_stats/__main__.py
+++ b/dapp_stats/__main__.py
@@ -1,12 +1,11 @@
 import click
+from click import ClickException
 from functools import wraps
 import json
 import logging
 from pathlib import Path
 import sys
 from typing import Sequence
-
-from click import Abort, ClickException
 
 from dapp_stats import DappStats
 from dapp_stats.dapp_size_resolver import DappSizeResolver, DappSizeResolverError
@@ -58,7 +57,9 @@ def size(descriptors: Sequence[Path]):
     """Calculates dApp defined payloads sizes (in bytes) on the provided set of descriptor files."""
 
     try:
-        measured_sizes, errors = DappSizeResolver.resolve_defined_payload_sizes(descriptors)
+        measured_sizes, errors = DappSizeResolver.resolve_defined_payload_sizes(
+            descriptors
+        )
     except DappSizeResolverError as e:
         raise ClickException(str(e))
 

--- a/dapp_stats/dapp_size_resolver.py
+++ b/dapp_stats/dapp_size_resolver.py
@@ -1,16 +1,18 @@
 import base64
-import json
-from pathlib import Path
-from typing import List, TypedDict, Dict, Tuple, Callable, Sequence
-from urllib import request
-
 from dapp_runner.descriptor import DappDescriptor
 from dapp_runner.descriptor.dapp import PayloadDescriptor
 from dapp_runner.descriptor.parser import load_yamls
-from yapapi.payload.vm import resolve_repo_srv, _DEFAULT_REPO_SRV
+import json
+from pathlib import Path
+from typing import Callable, Dict, List, Sequence, Tuple, TypedDict
+from urllib import request
+from urllib.error import HTTPError
+from yapapi.payload.vm import _DEFAULT_REPO_SRV, resolve_repo_srv
+
 
 class DappSizeResolverError(Exception):
     pass
+
 
 class ResolvedPayloadSizes(TypedDict):
     total_size: int
@@ -19,77 +21,117 @@ class ResolvedPayloadSizes(TypedDict):
 
 class DappSizeResolver:
     @classmethod
-    def resolve_payload_size(cls, descriptor_paths: Sequence[Path]) -> Tuple[ResolvedPayloadSizes, List[str]]:
+    def resolve_defined_payload_sizes(
+        cls, descriptor_paths: Sequence[Path]
+    ) -> Tuple[ResolvedPayloadSizes, List[str]]:
         payloads_sizes = {}
         errors = []
-        resolvers = {
-            'vm': cls._resolve_payload_size_for_vm_runtime,
-            'vm/manifest': cls._resolve_payload_size_for_vm_manifest_runtime,
+        size_resolvers = {
+            "vm": cls._resolve_payload_size_for_vm_runtime,
+            "vm/manifest": cls._resolve_payload_size_for_vm_manifest_runtime,
         }
 
         dapp = cls._get_dapp_from_descriptor_paths(descriptor_paths)
 
         for payload_name, payload in dapp.payloads.items():
-            resolver: Callable[[PayloadDescriptor], int] = resolvers.get(payload.runtime, cls._resolve_payload_size_for_unknown_runtime)
+            size_resolver: Callable[[PayloadDescriptor], int] = size_resolvers.get(
+                payload.runtime, cls._resolve_payload_size_for_unknown_runtime
+            )
 
             try:
-                payload_size = resolver(payload)
+                payload_size = size_resolver(payload)
             except DappSizeResolverError as e:
-                errors.append(f'Ignoring payload "{payload_name}" as following error occurred: {e}')
+                errors.append(
+                    f'Ignoring payload "{payload_name}" as following error occurred: {e}'
+                )
             else:
                 payloads_sizes[payload_name] = payload_size
 
         return {
-            'total_size': sum(payloads_sizes.values()),
-            'payloads': payloads_sizes,
+            "total_size": sum(payloads_sizes.values()),
+            "payloads": payloads_sizes,
         }, errors
 
     @classmethod
-    def _get_dapp_from_descriptor_paths(cls, descriptor_paths: Sequence[Path]) -> DappDescriptor:
-        dapp_dict = load_yamls(*descriptor_paths)
-        return DappDescriptor.load(dapp_dict)
+    def _get_dapp_from_descriptor_paths(
+        cls, descriptor_paths: Sequence[Path]
+    ) -> DappDescriptor:
+        try:
+            dapp_dict = load_yamls(*descriptor_paths)
+        except FileNotFoundError as e:
+            raise DappSizeResolverError(f"Failed to load descriptor files: {e}")
+
+        try:
+            return DappDescriptor.load(dapp_dict)
+        except Exception as e:
+            raise DappSizeResolverError(f"Failed to validate descriptor files: {e}")
 
     @classmethod
     def _resolve_payload_size_for_vm_runtime(cls, payload: PayloadDescriptor) -> int:
         try:
-            image_hash = payload.params['image_hash']
-        except KeyError:
-            raise DappSizeResolverError(f'Field "image_hash" is not present in payload params!')
+            image_hash = payload.params["image_hash"]
+        except (TypeError, KeyError):
+            raise DappSizeResolverError(
+                f'Field "image_hash" is not present in payload params!'
+            )
 
+        image_url = cls._fetch_image_url_from_image_hash(image_hash)
+
+        return cls._fetch_payload_size_from_image_url(image_url)
+
+    @classmethod
+    def _resolve_payload_size_for_vm_manifest_runtime(
+        cls, payload: PayloadDescriptor
+    ) -> int:
+        try:
+            manifest_hash = payload.params["manifest"]
+        except KeyError:
+            raise DappSizeResolverError(
+                'Field "manifest" is not present in payload params!'
+            )
+
+        try:
+            manifest = json.loads(base64.b64decode(manifest_hash.encode("utf-8")))
+        except Exception:
+            raise DappSizeResolverError(
+                'Field "manifest" is not properly Base64 encoded JSON object!'
+            )
+
+        try:
+            image_url = manifest["payload"][0]["urls"][0]
+        except (KeyError, IndexError):
+            raise DappSizeResolverError("Payload url is not present in manifest!")
+
+        return cls._fetch_payload_size_from_image_url(image_url)
+
+    @classmethod
+    def _resolve_payload_size_for_unknown_runtime(
+        cls, payload: PayloadDescriptor
+    ) -> int:
+        raise DappSizeResolverError(
+            f'Size measurement for runtime "{payload.runtime}" is not supported!'
+        )
+
+    @classmethod
+    def _fetch_image_url_from_image_hash(cls, image_hash: str) -> str:
         repo_url = resolve_repo_srv(_DEFAULT_REPO_SRV)
         repo_package_url = f"{repo_url}/image.{image_hash}.link"
 
-        image_url = cls._fetch_image_url_from_repo_package_url(repo_package_url)
-
-        return cls._fetch_payload_size_from_image_url(image_url)
-
-    @classmethod
-    def _resolve_payload_size_for_vm_manifest_runtime(cls, payload: PayloadDescriptor) -> int:
         try:
-            manifest_hash = payload.params['manifest']
-        except KeyError:
-            raise DappSizeResolverError('Field "manifest" is not present in payload params!')
-
-        manifest = json.loads(base64.b64decode(manifest_hash.encode('utf-8')))
-
-        try:
-            image_url = manifest['payload'][0]['urls'][0]
-        except (KeyError, IndexError):
-            raise DappSizeResolverError('Payload url is not present in manifest!')
-
-        return cls._fetch_payload_size_from_image_url(image_url)
-
-    @classmethod
-    def _resolve_payload_size_for_unknown_runtime(cls, payload: PayloadDescriptor) -> int:
-        raise DappSizeResolverError(f'Size measurement for runtime "{payload.runtime}" is not supported!')
-
-    @classmethod
-    def _fetch_image_url_from_repo_package_url(cls, repo_package_url: str) -> str:
-        return cls._fetch_http_response_body(repo_package_url).decode('utf-8')
+            return cls._fetch_http_response_body(repo_package_url).decode("utf-8")
+        except HTTPError as e:
+            raise DappSizeResolverError(
+                f'Can\'t fetch image url from image hash "{image_hash}" via url "{repo_package_url}": {e}'
+            )
 
     @classmethod
     def _fetch_payload_size_from_image_url(cls, image_url: str) -> int:
-        return int(cls._fetch_http_response_header(image_url, 'Content-Length'))
+        try:
+            return int(cls._fetch_http_response_header(image_url, "Content-Length"))
+        except HTTPError as e:
+            raise DappSizeResolverError(
+                f'Can\'t fetch payload size from image url "{image_url}": {e}'
+            )
 
     @classmethod
     def _fetch_http_response_body(cls, url: str) -> bytes:

--- a/dapp_stats/dapp_size_resolver.py
+++ b/dapp_stats/dapp_size_resolver.py
@@ -1,0 +1,102 @@
+import base64
+import json
+from pathlib import Path
+from typing import List, TypedDict, Dict, Tuple, Callable, Sequence
+from urllib import request
+
+from dapp_runner.descriptor import DappDescriptor
+from dapp_runner.descriptor.dapp import PayloadDescriptor
+from dapp_runner.descriptor.parser import load_yamls
+from yapapi.payload.vm import resolve_repo_srv, _DEFAULT_REPO_SRV
+
+class DappSizeResolverError(Exception):
+    pass
+
+class ResolvedPayloadSizes(TypedDict):
+    total_size: int
+    payloads: Dict[str, int]
+
+
+class DappSizeResolver:
+    @classmethod
+    def resolve_payload_size(cls, descriptor_paths: Sequence[Path]) -> Tuple[ResolvedPayloadSizes, List[str]]:
+        payloads_sizes = {}
+        errors = []
+        resolvers = {
+            'vm': cls._resolve_payload_size_for_vm_runtime,
+            'vm/manifest': cls._resolve_payload_size_for_vm_manifest_runtime,
+        }
+
+        dapp = cls._get_dapp_from_descriptor_paths(descriptor_paths)
+
+        for payload_name, payload in dapp.payloads.items():
+            resolver: Callable[[PayloadDescriptor], int] = resolvers.get(payload.runtime, cls._resolve_payload_size_for_unknown_runtime)
+
+            try:
+                payload_size = resolver(payload)
+            except DappSizeResolverError as e:
+                errors.append(f'Ignoring payload "{payload_name}" as following error occurred: {e}')
+            else:
+                payloads_sizes[payload_name] = payload_size
+
+        return {
+            'total_size': sum(payloads_sizes.values()),
+            'payloads': payloads_sizes,
+        }, errors
+
+    @classmethod
+    def _get_dapp_from_descriptor_paths(cls, descriptor_paths: Sequence[Path]) -> DappDescriptor:
+        dapp_dict = load_yamls(*descriptor_paths)
+        return DappDescriptor.load(dapp_dict)
+
+    @classmethod
+    def _resolve_payload_size_for_vm_runtime(cls, payload: PayloadDescriptor) -> int:
+        try:
+            image_hash = payload.params['image_hash']
+        except KeyError:
+            raise DappSizeResolverError(f'Field "image_hash" is not present in payload params!')
+
+        repo_url = resolve_repo_srv(_DEFAULT_REPO_SRV)
+        repo_package_url = f"{repo_url}/image.{image_hash}.link"
+
+        image_url = cls._fetch_image_url_from_repo_package_url(repo_package_url)
+
+        return cls._fetch_payload_size_from_image_url(image_url)
+
+    @classmethod
+    def _resolve_payload_size_for_vm_manifest_runtime(cls, payload: PayloadDescriptor) -> int:
+        try:
+            manifest_hash = payload.params['manifest']
+        except KeyError:
+            raise DappSizeResolverError('Field "manifest" is not present in payload params!')
+
+        manifest = json.loads(base64.b64decode(manifest_hash.encode('utf-8')))
+
+        try:
+            image_url = manifest['payload'][0]['urls'][0]
+        except (KeyError, IndexError):
+            raise DappSizeResolverError('Payload url is not present in manifest!')
+
+        return cls._fetch_payload_size_from_image_url(image_url)
+
+    @classmethod
+    def _resolve_payload_size_for_unknown_runtime(cls, payload: PayloadDescriptor) -> int:
+        raise DappSizeResolverError(f'Size measurement for runtime "{payload.runtime}" is not supported!')
+
+    @classmethod
+    def _fetch_image_url_from_repo_package_url(cls, repo_package_url: str) -> str:
+        return cls._fetch_http_response_body(repo_package_url).decode('utf-8')
+
+    @classmethod
+    def _fetch_payload_size_from_image_url(cls, image_url: str) -> int:
+        return int(cls._fetch_http_response_header(image_url, 'Content-Length'))
+
+    @classmethod
+    def _fetch_http_response_body(cls, url: str) -> bytes:
+        with request.urlopen(url) as response:
+            return response.read()
+
+    @classmethod
+    def _fetch_http_response_header(cls, url: str, header: str) -> bytes:
+        with request.urlopen(url) as response:
+            return response.headers[header]

--- a/dapp_stats/dapp_size_resolver.py
+++ b/dapp_stats/dapp_size_resolver.py
@@ -84,14 +84,14 @@ class DappSizeResolver:
         cls, payload: PayloadDescriptor
     ) -> int:
         try:
-            manifest_hash = payload.params["manifest"]
+            manifest_base64 = payload.params["manifest"]
         except KeyError:
             raise DappSizeResolverError(
                 'Field "manifest" is not present in payload params!'
             )
 
         try:
-            manifest = json.loads(base64.b64decode(manifest_hash.encode("utf-8")))
+            manifest = json.loads(base64.b64decode(manifest_base64.encode("utf-8")))
         except Exception:
             raise DappSizeResolverError(
                 'Field "manifest" is not properly Base64 encoded JSON object!'

--- a/dapp_stats/statistics/models.py
+++ b/dapp_stats/statistics/models.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Dict, Optional
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,12 @@ autoflake = "^2.0.0"
 dapp-manager = "dapp_manager.__main__:main"
 dapp-stats = "dapp_stats.__main__:main"
 
+[tool.autoflake]
+recursive = true
+in-place = true
+remove-all-unused-imports = true
+ignore-init-module-imports = true
+
 [tool.isort]
 profile = "black"
 force_sort_within_sections = true
@@ -81,7 +87,7 @@ unauthorized_licenses = ["gpl v3"]
 _codestyle_isort = "isort --check-only --diff ."
 _codestyle_black = "black --check --diff ."
 codestyle = ["_codestyle_isort", "_codestyle_black"]
-_format_autoflake = "autoflake --in-place ."
+_format_autoflake = "autoflake --in-place -r ."
 _format_isort = " isort ."
 _format_black = "black ."
 format = ["_format_autoflake", "_format_isort", "_format_black"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ pytest = "^7.1"
 pytest-cov = "^3.0.0"
 pytest-mock = "^3.10.0"
 liccheck = "^0.7.2"
+autoflake = "^2.0.0"
 
 [tool.poetry.scripts]
 dapp-manager = "dapp_manager.__main__:main"
@@ -62,6 +63,7 @@ authorized_licenses = [
   "apache 2",
   "apache",
   "Apache Software",
+  "Apache Software License",
   "MPL-2.0",
   "Mozilla Public License 2.0 (MPL 2.0)",
   "MIT",
@@ -79,6 +81,10 @@ unauthorized_licenses = ["gpl v3"]
 _codestyle_isort = "isort --check-only --diff ."
 _codestyle_black = "black --check --diff ."
 codestyle = ["_codestyle_isort", "_codestyle_black"]
+_format_autoflake = "autoflake --in-place ."
+_format_isort = " isort ."
+_format_black = "black ."
+format = ["_format_autoflake", "_format_isort", "_format_black"]
 typecheck = "mypy --install-types --non-interactive --ignore-missing-imports --check-untyped-defs --warn-unused-ignores --show-error-codes ."
 _liccheck_export = "poetry export -f requirements.txt -o .requirements.txt"
 _liccheck_verify = "liccheck -r .requirements.txt"

--- a/tests/assets/descriptors/bad_validation.yaml
+++ b/tests/assets/descriptors/bad_validation.yaml
@@ -1,0 +1,7 @@
+payload:
+  - a
+nodes:
+  a:
+    payload: "a"
+extra_key:
+  foo: "bar"

--- a/tests/assets/descriptors/bad_vm_manifest_runtime_corrupted_manifest.yaml
+++ b/tests/assets/descriptors/bad_vm_manifest_runtime_corrupted_manifest.yaml
@@ -1,0 +1,8 @@
+payloads:
+  a:
+    runtime: "vm/manifest"
+    params:
+      manifest: "bad base64"
+nodes:
+  a:
+    payload: "a"

--- a/tests/assets/descriptors/bad_vm_manifest_runtime_without_image_url.yaml
+++ b/tests/assets/descriptors/bad_vm_manifest_runtime_without_image_url.yaml
@@ -1,0 +1,14 @@
+payloads:
+  a:
+    runtime: "vm/manifest"
+    params:
+      manifest: "eyJwYXlsb2FkIjogW3sidXJscyI6IFtdfV19"
+  b:
+    runtime: "vm/manifest"
+    params:
+      manifest: "e30="
+nodes:
+  a:
+    payload: "a"
+  b:
+    payload: "b"

--- a/tests/assets/descriptors/bad_vm_manifest_runtime_without_manifest.yaml
+++ b/tests/assets/descriptors/bad_vm_manifest_runtime_without_manifest.yaml
@@ -1,0 +1,8 @@
+payloads:
+  a:
+    runtime: "vm/manifest"
+    params:
+      foo: "bar"
+nodes:
+  a:
+    payload: "a"

--- a/tests/assets/descriptors/bad_vm_runtime_not_existing_image_hash.yaml
+++ b/tests/assets/descriptors/bad_vm_runtime_not_existing_image_hash.yaml
@@ -1,0 +1,8 @@
+payloads:
+  a:
+    runtime: "vm"
+    params:
+      image_hash: "not_existing"
+nodes:
+  a:
+    payload: "a"

--- a/tests/assets/descriptors/bad_vm_runtime_without_image_hash.yaml
+++ b/tests/assets/descriptors/bad_vm_runtime_without_image_hash.yaml
@@ -1,0 +1,8 @@
+payloads:
+  a:
+    runtime: "vm"
+    params:
+      foo: bar
+nodes:
+  a:
+    payload: "a"

--- a/tests/assets/descriptors/correct_vm_manifest_runtime_a.yaml
+++ b/tests/assets/descriptors/correct_vm_manifest_runtime_a.yaml
@@ -1,0 +1,8 @@
+payloads:
+  a:
+    runtime: "vm/manifest"
+    params:
+      manifest: "eyJwYXlsb2FkIjogW3sidXJscyI6IFsic29tZV91cmwiXX1dfQ=="
+nodes:
+  a:
+    payload: "a"

--- a/tests/assets/descriptors/correct_vm_manifest_runtime_ab.yaml
+++ b/tests/assets/descriptors/correct_vm_manifest_runtime_ab.yaml
@@ -1,0 +1,14 @@
+payloads:
+  a:
+    runtime: "vm/manifest"
+    params:
+      manifest: "eyJwYXlsb2FkIjogW3sidXJscyI6IFsic29tZV91cmwiXX1dfQ=="
+  b:
+    runtime: "vm/manifest"
+    params:
+      manifest: "eyJwYXlsb2FkIjogW3sidXJscyI6IFsic29tZV91cmwiXX1dfQ=="
+nodes:
+  a:
+    payload: "a"
+  b:
+    payload: "b"

--- a/tests/assets/descriptors/correct_vm_manifest_runtime_b.yaml
+++ b/tests/assets/descriptors/correct_vm_manifest_runtime_b.yaml
@@ -1,0 +1,8 @@
+payloads:
+  b:
+    runtime: "vm/manifest"
+    params:
+      manifest: "eyJwYXlsb2FkIjogW3sidXJscyI6IFsic29tZV9vdGhlcl91cmwiXX1dfQ=="
+nodes:
+  b:
+    payload: "b"

--- a/tests/assets/descriptors/correct_vm_runtime_a.yaml
+++ b/tests/assets/descriptors/correct_vm_runtime_a.yaml
@@ -1,0 +1,8 @@
+payloads:
+  a:
+    runtime: "vm"
+    params:
+      image_hash: "a_image_hash"
+nodes:
+  a:
+    payload: "a"

--- a/tests/assets/descriptors/correct_vm_runtime_ab.yaml
+++ b/tests/assets/descriptors/correct_vm_runtime_ab.yaml
@@ -1,0 +1,14 @@
+payloads:
+  a:
+    runtime: "vm"
+    params:
+      image_hash: "a_image_hash"
+  b:
+    runtime: "vm"
+    params:
+      image_hash: "b_image_hash"
+nodes:
+  a:
+    payload: "a"
+  b:
+    payload: "b"

--- a/tests/assets/descriptors/correct_vm_runtime_b.yaml
+++ b/tests/assets/descriptors/correct_vm_runtime_b.yaml
@@ -1,0 +1,8 @@
+payloads:
+  b:
+    runtime: "vm"
+    params:
+      image_hash: "b_image_hash"
+nodes:
+  b:
+    payload: "b"

--- a/tests/assets/descriptors/unsupported_runtime.yaml
+++ b/tests/assets/descriptors/unsupported_runtime.yaml
@@ -1,0 +1,8 @@
+payloads:
+  a:
+    runtime: "unsupported or something..."
+    params:
+      some: "value"
+nodes:
+  a:
+    payload: "a"

--- a/tests/dapp_stats/test_dapp_size_resolver.py
+++ b/tests/dapp_stats/test_dapp_size_resolver.py
@@ -1,8 +1,7 @@
-from email.message import Message
 from pathlib import Path
 import pytest
 from typing import List
-from urllib.error import HTTPError, URLError
+from urllib.error import HTTPError
 
 from dapp_stats.dapp_size_resolver import DappSizeResolver, DappSizeResolverError
 

--- a/tests/dapp_stats/test_dapp_size_resolver.py
+++ b/tests/dapp_stats/test_dapp_size_resolver.py
@@ -1,0 +1,264 @@
+from email.message import Message
+from pathlib import Path
+import pytest
+from typing import List
+from urllib.error import HTTPError, URLError
+
+from dapp_stats.dapp_size_resolver import DappSizeResolver, DappSizeResolverError
+
+
+@pytest.fixture
+def dapp_size_resolver():
+    return DappSizeResolver
+
+
+@pytest.mark.parametrize(
+    "descriptor_paths, mocked_sizes, expected_sizes, expected_errors",
+    (
+        (
+            (Path("tests/assets/descriptors/correct_vm_runtime_a.yaml"),),
+            ("123",),
+            {"total_size": 123, "payloads": {"a": 123}},
+            [],
+        ),
+        (
+            (Path("tests/assets/descriptors/correct_vm_runtime_ab.yaml"),),
+            ("123", "321"),
+            {"total_size": 444, "payloads": {"a": 123, "b": 321}},
+            [],
+        ),
+        (
+            (
+                Path("tests/assets/descriptors/correct_vm_runtime_a.yaml"),
+                Path("tests/assets/descriptors/correct_vm_runtime_b.yaml"),
+            ),
+            ("123", "321"),
+            {"total_size": 444, "payloads": {"a": 123, "b": 321}},
+            [],
+        ),
+    ),
+)
+def test_resolve_vm_runtime_payload_size(
+    dapp_size_resolver,
+    descriptor_paths,
+    mocked_sizes,
+    expected_sizes,
+    expected_errors,
+    mocker,
+):
+    mocked_image_url_from_repo_package_url = mocker.Mock(
+        **{"read.return_value": b"some_gvmi_link"}
+    )
+
+    mocked_urlopen = mocker.patch("dapp_stats.dapp_size_resolver.request.urlopen")
+    urlopen_mocks = []
+    for mocked_size in mocked_sizes:
+        mocked_payload_size_from_image_url = mocker.Mock(
+            headers={"Content-Length": mocked_size}
+        )
+
+        urlopen_mocks.extend(
+            [
+                mocked_image_url_from_repo_package_url,
+                mocked_payload_size_from_image_url,
+            ]
+        )
+
+    mocked_urlopen.return_value.__enter__.side_effect = urlopen_mocks
+
+    sizes, errors = dapp_size_resolver.resolve_defined_payload_sizes(descriptor_paths)
+
+    assert errors == expected_errors
+    assert sizes == expected_sizes
+
+
+def test_resolve_vm_runtime_payload_size_missing_image_hash(dapp_size_resolver):
+    sizes, errors = dapp_size_resolver.resolve_defined_payload_sizes(
+        [Path("tests/assets/descriptors/bad_vm_runtime_without_image_hash.yaml")]
+    )
+
+    assert errors == [
+        'Ignoring payload "a" as following error occurred: Field "image_hash" is not present in payload params!'
+    ]
+    assert sizes == {"total_size": 0, "payloads": {}}
+
+
+def test_resolve_vm_runtime_payload_size_image_hash_not_found_in_repo(
+    dapp_size_resolver, mocker
+):
+    mocked_urlopen = mocker.patch("dapp_stats.dapp_size_resolver.request.urlopen")
+    mocked_urlopen.side_effect = HTTPError(
+        "some_url", 404, "not found?!", mocker.Mock(), None
+    )
+
+    sizes, errors = dapp_size_resolver.resolve_defined_payload_sizes(
+        [Path("tests/assets/descriptors/bad_vm_runtime_not_existing_image_hash.yaml")]
+    )
+
+    assert len(errors) == 1
+    assert "Can't fetch image url from image hash" in errors[0]
+    assert sizes == {"total_size": 0, "payloads": {}}
+
+
+def test_resolve_vm_runtime_payload_size_image_url_not_found(
+    dapp_size_resolver, mocker
+):
+    mocked_urlopen = mocker.patch("dapp_stats.dapp_size_resolver.request.urlopen")
+    mocked_urlopen.return_value.__enter__.side_effect = [
+        mocker.Mock(**{"read.return_value": b"some_gvmi_link"}),
+        HTTPError("some_url", 404, "not found?!", mocker.Mock(), None),
+    ]
+
+    sizes, errors = dapp_size_resolver.resolve_defined_payload_sizes(
+        [Path("tests/assets/descriptors/bad_vm_runtime_not_existing_image_hash.yaml")]
+    )
+
+    assert len(errors) == 1
+    assert "Can't fetch payload size from image url" in errors[0]
+    assert sizes == {"total_size": 0, "payloads": {}}
+
+
+@pytest.mark.parametrize(
+    "descriptor_paths, mocked_sizes, expected_sizes, expected_errors",
+    (
+        (
+            (Path("tests/assets/descriptors/correct_vm_manifest_runtime_a.yaml"),),
+            ("123",),
+            {"total_size": 123, "payloads": {"a": 123}},
+            [],
+        ),
+        (
+            (Path("tests/assets/descriptors/correct_vm_manifest_runtime_ab.yaml"),),
+            ("123", "321"),
+            {"total_size": 444, "payloads": {"a": 123, "b": 321}},
+            [],
+        ),
+        (
+            (
+                Path("tests/assets/descriptors/correct_vm_manifest_runtime_a.yaml"),
+                Path("tests/assets/descriptors/correct_vm_manifest_runtime_b.yaml"),
+            ),
+            ("123", "321"),
+            {"total_size": 444, "payloads": {"a": 123, "b": 321}},
+            [],
+        ),
+    ),
+)
+def test_resolve_vm_manifest_runtime_payload_size(
+    dapp_size_resolver,
+    descriptor_paths,
+    mocked_sizes,
+    expected_sizes,
+    expected_errors,
+    mocker,
+):
+    mocked_urlopen = mocker.patch("dapp_stats.dapp_size_resolver.request.urlopen")
+    mocked_urlopen.return_value.__enter__.side_effect = [
+        mocker.Mock(headers={"Content-Length": mocked_size})
+        for mocked_size in mocked_sizes
+    ]
+
+    sizes, errors = dapp_size_resolver.resolve_defined_payload_sizes(descriptor_paths)
+
+    assert errors == expected_errors
+    assert sizes == expected_sizes
+
+
+def test_resolve_vm_manifest_runtime_payload_size_missing_manifest(dapp_size_resolver):
+    sizes, errors = dapp_size_resolver.resolve_defined_payload_sizes(
+        [Path("tests/assets/descriptors/bad_vm_manifest_runtime_without_manifest.yaml")]
+    )
+
+    assert errors == [
+        'Ignoring payload "a" as following error occurred: Field "manifest" is not present in payload params!'
+    ]
+    assert sizes == {"total_size": 0, "payloads": {}}
+
+
+def test_resolve_vm_manifest_runtime_payload_size_corrupted_manifest(
+    dapp_size_resolver,
+):
+    sizes, errors = dapp_size_resolver.resolve_defined_payload_sizes(
+        [
+            Path(
+                "tests/assets/descriptors/bad_vm_manifest_runtime_corrupted_manifest.yaml"
+            )
+        ]
+    )
+
+    assert errors == [
+        'Ignoring payload "a" as following error occurred: Field "manifest" is not properly Base64 encoded JSON object!'
+    ]
+    assert sizes == {"total_size": 0, "payloads": {}}
+
+
+def test_resolve_vm_manifest_runtime_payload_size_no_image_url_in_manifest(
+    dapp_size_resolver,
+):
+    sizes, errors = dapp_size_resolver.resolve_defined_payload_sizes(
+        [
+            Path(
+                "tests/assets/descriptors/bad_vm_manifest_runtime_without_image_url.yaml"
+            )
+        ]
+    )
+
+    assert errors == [
+        'Ignoring payload "a" as following error occurred: Payload url is not present in manifest!',
+        'Ignoring payload "b" as following error occurred: Payload url is not present in manifest!',
+    ]
+    assert sizes == {"total_size": 0, "payloads": {}}
+
+
+def test_resolve_combined_runtime_payload_size(dapp_size_resolver, mocker):
+    descriptor_paths = (
+        Path("tests/assets/descriptors/correct_vm_runtime_a.yaml"),
+        Path("tests/assets/descriptors/correct_vm_manifest_runtime_b.yaml"),
+    )
+    expected_sizes = {"total_size": 444, "payloads": {"a": 123, "b": 321}}
+    expected_errors: List[str] = []
+
+    mocked_image_url_from_repo_package_url = mocker.Mock(
+        **{"read.return_value": b"some_gvmi_link"}
+    )
+    mocked_payload_size_from_image_urls = [
+        mocker.Mock(headers={"Content-Length": "123"}),
+        mocker.Mock(headers={"Content-Length": "321"}),
+    ]
+
+    mocked_urlopen = mocker.patch("dapp_stats.dapp_size_resolver.request.urlopen")
+
+    mocked_urlopen.return_value.__enter__.side_effect = [
+        mocked_image_url_from_repo_package_url,
+        *mocked_payload_size_from_image_urls,
+    ]
+
+    sizes, errors = dapp_size_resolver.resolve_defined_payload_sizes(descriptor_paths)
+
+    assert errors == expected_errors
+    assert sizes == expected_sizes
+
+
+def test_resolve_payload_size_descriptor_not_found(dapp_size_resolver):
+    with pytest.raises(DappSizeResolverError, match="Failed to load descriptor files"):
+        dapp_size_resolver.resolve_defined_payload_sizes([Path("not existing")])
+
+
+def test_resolve_payload_size_descriptor_validation_errors(dapp_size_resolver):
+    with pytest.raises(
+        DappSizeResolverError, match="Failed to validate descriptor files"
+    ):
+        dapp_size_resolver.resolve_defined_payload_sizes(
+            [Path("tests/assets/descriptors/bad_validation.yaml")]
+        )
+
+
+def test_resolve_payload_size_unknown_payload_runtime(dapp_size_resolver):
+    sizes, errors = dapp_size_resolver.resolve_defined_payload_sizes(
+        [Path("tests/assets/descriptors/unsupported_runtime.yaml")]
+    )
+
+    assert errors == [
+        'Ignoring payload "a" as following error occurred: Size measurement for runtime "unsupported or something..." is not supported!'
+    ]
+    assert sizes == {"total_size": 0, "payloads": {}}

--- a/tests/dapp_stats/test_dapp_stats.py
+++ b/tests/dapp_stats/test_dapp_stats.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 from typing import List
-from unittest.mock import patch
 
 from dapp_stats import DappStats
 


### PR DESCRIPTION
What have been done:

- New CLI command `dapp-stats size [descriptors...]` that can read provided descriptors and resolve their defined payload sizes and respond with a JSON object. Skippable errors will be printed on stderr, with exec return code 0. Non skippable errors will return with error code non-zero. Supported runtimes: `vm` and `vm/manifest`.
- Few code fixes to satisfy linters.
- Added dev dependency `autoflake` to remove unused code.
- Added `poetry run poe format` command to enforce codestyle where it can.
- Added another text variant for `Apache` license.

What I'm thinking about:
- I've added skippable errors... Because mostly of other / future unsupported runtimes. It happened that skippable error list grew, and now we have bunch of them that could fail per payload.
- Code layout for supported runtime size resolvers live inside the only public function. It could be moved as some external functions with a flow for registering resolvers, but for my taste, it would bring too much complexity at this stage.