### PR TITLE
Stabilization of flaky test

### DIFF
--- a/tests/test_manager_api.py
+++ b/tests/test_manager_api.py
@@ -175,7 +175,7 @@ def test_read_file_follow_logs_not_accessible_after_some_time(get_dapp, file_typ
     )
     assert dapp.alive
 
-    sleep(0.5)  # Wait for logs to be created
+    sleep(1)  # Wait for logs to be created
 
     mock_fname = asset_path(f"mock_{file_type}_file.txt")
 


### PR DESCRIPTION
#78 introduced `test_read_file_follow_logs_not_accessible_after_some_time` test that on CI could be time sensitive in its setup, hence flakyness. Simple extending sleep time to give more time to python process run underneath to feed log files at least fixes the problem.